### PR TITLE
Include use case for 2D arrays in FITS bintable

### DIFF
--- a/read_via_fits2.py
+++ b/read_via_fits2.py
@@ -1,20 +1,27 @@
 import pandas as pd
 from astropy.table import Table
 
-def read_fits_as_dataframe(filename, index_columns):
+def read_fits_as_dataframe(filename, index_columns=None):
     # This is the way to read the FITS data into a numpy structured array
     # (using astropy.io.fits.getdata didn't work out of the box
     # because it gives a FITSRec)
     table = Table.read(filename)
-    data = table._data
     # Fix byte order.
     # See https://github.com/astropy/astropy/issues/1156
-    data = data.byteswap().newbyteorder()
-    df = pd.DataFrame.from_records(data)
-    # Strip whitespace for string columns that will become indices
-    for index_column in index_columns:
-        df[index_column] = df[index_column].map(str.strip)
-    df = df.set_index(index_columns)
+    data  = {}
+    for key in table.keys():
+        if np.ndim(table.as_array()[key]) == 2:
+            for k in range(table.as_array()[key].shape[1]):
+                data[key + '_' + str(k)] = table.as_array()[key][:,k].byteswap().newbyteorder()
+        else:
+            data[key] = table.as_array()[key].byteswap().newbyteorder()
+    
+    df    = pd.DataFrame.from_records(data)
+    if index_columns is not None:
+        # Strip whitespace for string columns that will become indices
+        for index_column in index_columns:
+            df[index_column]  = df[index_column].map(str.strip)
+        df  = df.set_index(index_columns)
     return df
 
 df = read_fits_as_dataframe('table.fits', ['ROI', 'Solution'])


### PR DESCRIPTION
Thank you for finding the `.byteswap().newbyteorder()` usage; that solved my primary problem.  Then I received an error for "only 1-dimensional arrays" when converting to DataFrame.  This is when I noticed that I had 2D arrays in my bin tables (e.g. FLUX_APER and FLUX_ERROR_APER from source extractor).

The above changes add usage to 'flatten' 2D arrays (MxN) into N 1D arrays with subsequent keys "_0", "_1", "_2", "_3", ..., "_(N-1)"

I tried this on my data set, let me know if it works on your own as well.
